### PR TITLE
Fix 2x2 rule

### DIFF
--- a/python_tools/workflow_tools/ACCESS_filters.py
+++ b/python_tools/workflow_tools/ACCESS_filters.py
@@ -144,7 +144,7 @@ def create_fillout_summary(df_fillout, alt_thres):
     summary_table[fillout_type + 'median_VAF'] = df_fillout.groupby(mutation_key)['t_vaf_fragment'].median()
 
     # Find the number of samples with alt count above the threshold (alt_thres)
-    summary_table[fillout_type + 'n_fillout_sample_alt_detect'] = df_fillout.groupby(mutation_key)['t_alt_count_fragment'].aggregate(lambda x :(x>alt_thres).sum())
+    summary_table[fillout_type + 'n_fillout_sample_alt_detect'] = df_fillout.groupby(mutation_key)['t_alt_count_fragment'].aggregate(lambda x :(x>=alt_thres).sum())
 
     # Find the number of sample with the Total Depth is >0
     # 't_vaf_fragment' column is NA for samples where mutation had no coverage, so count() will exclude it


### PR DESCRIPTION
Changed the create_fillout_summary so that the number of samples with alt count above threshold includes samples with the alt_thres (>= instead of >). This corrects the 2x2 rule in the filters.