### PR TITLE
New fix to 2x2 rule

### DIFF
--- a/python_tools/workflow_tools/ACCESS_filters.py
+++ b/python_tools/workflow_tools/ACCESS_filters.py
@@ -144,7 +144,7 @@ def create_fillout_summary(df_fillout, alt_thres):
     summary_table[fillout_type + 'median_VAF'] = df_fillout.groupby(mutation_key)['t_vaf_fragment'].median()
 
     # Find the number of samples with alt count above the threshold (alt_thres)
-    summary_table[fillout_type + 'n_fillout_sample_alt_detect'] = df_fillout.groupby(mutation_key)['t_alt_count_fragment'].aggregate(lambda x :(x>alt_thres).sum())
+    summary_table[fillout_type + 'n_fillout_sample_alt_detect'] = df_fillout.groupby(mutation_key)['t_alt_count_fragment'].aggregate(lambda x :(x>=alt_thres).sum())
 
     # Find the number of sample with the Total Depth is >0
     # 't_vaf_fragment' column is NA for samples where mutation had no coverage, so count() will exclude it
@@ -260,7 +260,7 @@ def apply_filter_maf (df_pre_filter, blacklist, args):
         # TODO: ASK MIKE: add truncated mutations to below threshold 'Nonsense_Mutation', 'Splice_Site', 'Frame_Shift_Ins', 'Frame_Shift_Del'
         
     def occurrence_in_curated (mut, status, args):
-        if mut['CURATED-DUPLEX_n_fillout_sample_alt_detect'] > args.min_n_curated_samples_alt_detected:
+        if mut['CURATED-DUPLEX_n_fillout_sample_alt_detect'] >= args.min_n_curated_samples_alt_detected:
             status = status + 'InCurated;'
         return status
     


### PR DESCRIPTION
Fix so the InCurated (2x2 rule) works properly. Presviously was the 3x3 rule. First change changes all the columns ending in  “_n_fillout_sample_alt_detect” in the *filtered.maf files so that it counts all samples in its batch with >= the alt_thres. The second change tags all samples with >=  min_n_curated_samples_alt_detected.