### PR TITLE
Fix seek error when combining PDFs during QC

### DIFF
--- a/python_tools/workflow_tools/qc/combine_qc_pdfs.py
+++ b/python_tools/workflow_tools/qc/combine_qc_pdfs.py
@@ -14,7 +14,7 @@ def combine_pdfs(args):
 
     for pdf in args.pdf_files:
         logging.info(pdf)
-        merger.append(open(pdf), 'rb')
+        merger.append(open(pdf, 'rb'))
 
     with open('./' + FINAL_QC_FILENAME, 'wb') as fout:
         merger.write(fout)


### PR DESCRIPTION
Came across this when updating to Python 3 in order to support Toil 4.2
Causes seek error in PyPDF2 if file not opened with 'b' flag
See: https://stackoverflow.com/questions/21533391/seeking-from-end-of-file-throwing-unsupported-exception