### PR TITLE
Ij/complex genotyping

### DIFF
--- a/cwl_tools/basicfiltering/filter_vardict.py
+++ b/cwl_tools/basicfiltering/filter_vardict.py
@@ -97,7 +97,7 @@ def run_std_filter(args):
     vcf_reader.formats['DP'] = VcfFormat('DP', '1', 'Integer', 'Total read depth at this site')
     vcf_reader.formats['AD'] = VcfFormat('AD', 'R', 'Integer', 'Allelic depths for the ref and alt alleles in the order listed')
     # Manually add the new SHIFT3_ADJUSTED header to the reader, which will then be passed to the writer
-    shift3_line = "##INFO=<ID=SHIFT3_ADJUSTED,Number=1,Type=Integer,Description=\"No. of bases to be shifted to 3 prime for deletions due to alternative alignment for complex variants\">"
+    shift3_line = "##INFO=<ID=SHIFT3_ADJUSTED,Number=1,Type=Integer,Description=\"No. of bases to be shifted to 5 prime for complex variants to get the preferred left alignment for proper genotyping\">"
     meta_parser = VcfMetadataParser()
     key, val = meta_parser.read_info(shift3_line)
     vcf_reader.infos[key] = val

--- a/cwl_tools/basicfiltering/filter_vardict.py
+++ b/cwl_tools/basicfiltering/filter_vardict.py
@@ -136,7 +136,7 @@ def run_std_filter(args):
             complex_flag = True
         else:
             complex_flag = False
-            record.INFO["SHIFT3_ADJUSTED"] = record.INFO["SHIFT3"]
+            record.INFO["SHIFT3_ADJUSTED"] = 0
 
         keep_based_on_status = True
         if "Somatic" not in record.INFO['STATUS'] and args.filter_germline:

--- a/cwl_tools/basicfiltering/filter_vardict.py
+++ b/cwl_tools/basicfiltering/filter_vardict.py
@@ -44,7 +44,7 @@ import time
 import logging
 import argparse
 
-from vcf.parser import _Info as VcfInfo, _Format as VcfFormat
+from vcf.parser import _Info as VcfInfo, _Format as VcfFormat, _vcf_metadata_parser as VcfMetadataParser
 
 from python_tools import cmo_util
 
@@ -96,6 +96,11 @@ def run_std_filter(args):
     vcf_reader.infos['set'] = VcfInfo('set', '.', 'String', 'The variant callers that reported this event', 'mskcc/basicfiltering', 'v0.2.1')
     vcf_reader.formats['DP'] = VcfFormat('DP', '1', 'Integer', 'Total read depth at this site')
     vcf_reader.formats['AD'] = VcfFormat('AD', 'R', 'Integer', 'Allelic depths for the ref and alt alleles in the order listed')
+    # Manually add the new SHIFT3_ADJUSTED header to the reader, which will then be passed to the writer
+    shift3_line = "##INFO=<ID=SHIFT3_ADJUSTED,Number=1,Type=Integer,Description=\"No. of bases to be shifted to 3 prime for deletions due to alternative alignment for complex variants\">"
+    meta_parser = VcfMetadataParser()
+    key, val = meta_parser.read_info(shift3_line)
+    vcf_reader.infos[key] = val
 
     allsamples = list(vcf_reader.samples)
 

--- a/cwl_tools/gbcms/gbcms.cwl
+++ b/cwl_tools/gbcms/gbcms.cwl
@@ -80,6 +80,11 @@ inputs:
     inputBinding:
       prefix: --fragment_count
 
+  generic_counting:
+    type: boolean
+    inputBinding:
+      prefix: --generic_counting
+
 outputs:
 
   fillout_out:

--- a/cwl_tools/gbcms/gbcms.cwl
+++ b/cwl_tools/gbcms/gbcms.cwl
@@ -6,8 +6,8 @@ requirements:
   InlineJavascriptRequirement: {}
   ShellCommandRequirement: {}
   ResourceRequirement:
-    ramMin: 32000
-    coresMin: 2
+    ramMin: 64000
+    coresMin: 4
   SchemaDefRequirement:
     types:
       - $import: ../../resources/schemas/variants_tools.yaml

--- a/cwl_tools/traceback/gbcm_traceback.cwl
+++ b/cwl_tools/traceback/gbcm_traceback.cwl
@@ -78,6 +78,11 @@ inputs:
     inputBinding:
       prefix: --fragment_count
 
+  generic_counting:
+    type: boolean
+    inputBinding:
+      prefix: --generic_counting
+
 outputs:
 
   tb_fillout_out:

--- a/cwl_tools/vardict/vardict_paired.cwl
+++ b/cwl_tools/vardict/vardict_paired.cwl
@@ -9,6 +9,9 @@ requirements:
       - $import: ../../resources/schemas/params/vardict.yaml
   InlineJavascriptRequirement: {}
   ShellCommandRequirement: {}
+  EnvVarRequirement:
+    envDef:
+      JAVA_HOME: "/opt/common/CentOS_6-dev/java/jdk1.8.0_31"
   ResourceRequirement:
     ramMin: 32000
     coresMin: 4

--- a/environment.yaml
+++ b/environment.yaml
@@ -7,6 +7,7 @@ channels:
 dependencies:
   - _libgcc_mutex=0.1=main
   - _r-mutex=1.0.0=anacondar_1
+  - bedtools=2.26.0=0
   - binutils_impl_linux-64=2.28.1
   - binutils_linux-64=7.2.0
   - bioconductor-dnacopy=1.58.0
@@ -138,6 +139,7 @@ dependencies:
   - r-yaml=2.2.0
   - r-zeallot=0.1.0
   - readline=7.0
+  - samtools=1.9
   - setuptools=42.0.2=py27_0
   - sqlite=3.30.1
   - tk=8.6.8

--- a/python_tools/cmo_util.py
+++ b/python_tools/cmo_util.py
@@ -46,7 +46,7 @@ def sort_vcf(vcf):
     subprocess.call(cmd)
 
 
-def bgzip(vcf):
+def bgzip(vcf, force=False):
     """
     gzip a VCF file
 
@@ -54,7 +54,12 @@ def bgzip(vcf):
     :return:
     """
     if re.search(r".gz$", vcf):
-        return vcf
+        if not force:
+            return vcf
+        else:
+            correct_vcf = re.sub(r".gz$", "", vcf)
+            os.rename(vcf, correct_vcf)
+            vcf = correct_vcf
 
     outfile = "%s.gz" % (vcf)
     cmd = [BGZIP_LOCATION, "-c", vcf]

--- a/resources/schemas/params/gbcms_params.yaml
+++ b/resources/schemas/params/gbcms_params.yaml
@@ -6,3 +6,4 @@ fields:
   thread: int
   maq: int
   fragment_count: int
+  generic_counting: boolean

--- a/workflows/module-4.cwl
+++ b/workflows/module-4.cwl
@@ -174,6 +174,8 @@ steps:
         valueFrom: $(inputs.gbcms_params.maq)
       fragment_count:
         valueFrom: $(inputs.gbcms_params.fragment_count)
+      generic_counting:
+        valueFrom: $(inputs.gbcms_params.generic_counting)
     out: [fillout_out]
 
   access_filters:

--- a/workflows/module-5.cwl
+++ b/workflows/module-5.cwl
@@ -161,6 +161,8 @@ steps:
         valueFrom: $(inputs.gbcms_params.maq)
       fragment_count:
         valueFrom: $(inputs.gbcms_params.fragment_count)
+      generic_counting:
+        valueFrom: $(inputs.gbcms_params.generic_counting)
     out: [tb_fillout_out]
 
   traceback_integrate:


### PR DESCRIPTION
It appears that we need to figure out a way to add the SHIFT3_ADJUSTED field as an INFO header in the vcf with a `type` of `Integer`. 

https://github.com/mskcc/ACCESS-Pipeline/pull/251/files#diff-a93c80de4e5a2d19172166846af07399386b4ebcbff465b2ce606f95a994f408R133

Otherwise this fails at the bcftools concat step:
```
[W::vcf_parse] INFO 'SHIFT3_ADJUSTED' is not defined in the header, assuming Type=String
[E::bcf_translate] Unchecked error (2), exiting
[job bcftools_concat.cwl] completed permanentFail
```

Once I manually added this to the header, the concat step completed successfully.

I'm not sure how we can use the PyVCF library to add this header though, as I don't see any functionality to add a new header in the API